### PR TITLE
Update `list_models` command to `models`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ From the head node, run the following commands.
 export AVIARY_URL="http://localhost:8000"
 
 # List the available models
-aviary list_models
+aviary models
 amazon/LightGPT
 
 # Query the model


### PR DESCRIPTION
There is no `list_models` command in `aviary`.

<img width="1440" alt="Screen Shot 2023-06-04 at 5 05 10 PM" src="https://github.com/ray-project/aviary/assets/20109646/72c1006b-2454-4979-a6db-5ab3efcbca8e">


# Test
<img width="1440" alt="Screen Shot 2023-06-04 at 5 06 39 PM" src="https://github.com/ray-project/aviary/assets/20109646/5b406fd3-87b4-4baa-9388-953daf0c24cc">
