### PR TITLE
Update `MOCK=True` to `AVIARY_MOCK=True`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,10 +224,10 @@ To just use the Gradio frontend without Ray Serve, you can start it
 with `python aviary/frontend/app.py`.
 
 If you don't have access to a deployed backend, or would just like to test and develop
-the frontend, you can run a mock backend locally by setting `MOCK=True`:
+the frontend, you can run a mock backend locally by setting `AVIARY_MOCK=True`:
 
 ```shell
-MOCK=True python aviary/frontend/app.py
+AVIARY_MOCK=True python aviary/frontend/app.py
 ```
 
 In any case, the Gradio interface should be accessible at `http://localhost:7860`


### PR DESCRIPTION
https://github.com/ray-project/aviary/blob/ac62571102ddd7d588da27c2aaff6e0454af8c61/aviary/common/backend.py#L29

The Aviary backend will read the environment variable `AVIARY_MOCK` instead of `MOCK`.

# Test
<img width="1083" alt="Screen Shot 2023-06-04 at 5 10 08 PM" src="https://github.com/ray-project/aviary/assets/20109646/55daeab1-32f8-4f88-859f-70a01856cd87">

<img width="1272" alt="Screen Shot 2023-06-04 at 5 10 58 PM" src="https://github.com/ray-project/aviary/assets/20109646/9367160c-829b-442c-a1aa-8ff409854766">
