### PR TITLE
fix: version string should be 0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="aviary",
-    version="0.1.1",
+    version="0.2.0",
     description="A tool to deploy and query LLMs",
     packages=find_packages(include="aviary*"),
     include_package_data=True,


### PR DESCRIPTION
Self-explanatory. We need to increase this value to ensure `pip list | grep aviary` and other pip metadata are reported correctly.

